### PR TITLE
Service name for unscd is unscd 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,10 +32,10 @@ template '/etc/nscd.conf' do
     settings: node['nscd'],
     databases: sanitize_databases(node['nscd']['databases'])
   )
-  notifies :restart, 'service[nscd]'
+  notifies :restart, "service[#{node['nscd']['package']}]"
 end
 
-service 'nscd' do
+service node['nscd']['package'] do
   service_name 'name-service-cache:default' if platform?('smartos')
   supports restart: true, status: true
   action   [:enable, :start]


### PR DESCRIPTION
### Description

trying out a fix for issue #8. Need to verify that unscd service is the name of the service for all platforms, and not just Debian. My laptop was crapping out on tests. Essentially just names the service based on the package name. 
### Issues Resolved

Issue: #8 
### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
