### PR TITLE
adding nscd cookbook parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installs and configures name service cache daemon (nscd). Provides a custom reso
 - compat_resource
 
 ## Attributes
-
+- `default['nscd']['template_cookbook']` - nscd cookbook name. You can ovverride this attribute if you want to pass in a custom template for nscd.conf
 - `default['nscd']['package']` - nscd package name, defaults to `nscd`. Other variants include: `unscd`, `gnscd`
 - `default['nscd']['version']` - nscd version, defaults to `nil`. If set to `nil`, the latest will be installed.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installs and configures name service cache daemon (nscd). Provides a custom reso
 - compat_resource
 
 ## Attributes
-- `default['nscd']['template_cookbook']` - nscd cookbook name. You can ovverride this attribute if you want to pass in a custom template for nscd.conf
+- `default['nscd']['template_cookbook']` - nscd cookbook name. You can override this attribute if you want to pass in a custom template for nscd.conf
 - `default['nscd']['package']` - nscd package name, defaults to `nscd`. Other variants include: `unscd`, `gnscd`
 - `default['nscd']['version']` - nscd version, defaults to `nil`. If set to `nil`, the latest will be installed.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 
 require 'etc'
 
-# nscd cookbook(incase you need to override anything in a wrapper)
+# nscd cookbook(in case you need to override anything in a wrapper)
 default['nscd']['template_cookbook'] = 'nscd'
 
 # Possible values: nscd, unscd, gnscd

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 require 'etc'
 
 # nscd cookbook(incase you need to override anything in a wrapper)
-default['nscd']['cookbook'] = 'nscd'
+default['nscd']['template_cookbook'] = 'nscd'
 
 # Possible values: nscd, unscd, gnscd
 default['nscd']['package'] = 'nscd'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,9 @@
 
 require 'etc'
 
+# nscd cookbook(incase you need to override anything in a wrapper)
+default['nscd']['cookbook'] = 'nscd'
+
 # Possible values: nscd, unscd, gnscd
 default['nscd']['package'] = 'nscd'
 default['nscd']['version'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,7 +32,7 @@ template '/etc/nscd.conf' do
     settings: node['nscd'],
     databases: sanitize_databases(node['nscd']['databases'])
   )
-  cookbook node['nscd']['cookbook']
+  cookbook node['nscd']['template_cookbook']
   notifies :restart, 'service[nscd]'
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,6 +32,7 @@ template '/etc/nscd.conf' do
     settings: node['nscd'],
     databases: sanitize_databases(node['nscd']['databases'])
   )
+  cookbook node['nscd']['cookbook']
   notifies :restart, 'service[nscd]'
 end
 


### PR DESCRIPTION
### Description

adding default['nscd']['cookbook'] so incase people need to override the default template or anything else this will give them the ability to do so. 

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


