### PR TITLE
Doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ nscd_clear_cache 'clear-nscd-caches' do
 end
 
 template '/etc/nsswitch.conf' do
-  notifies :run, 'nscd_clear_cache[clear-nscd-caches]', :immediately
+  notifies :clear, 'nscd_clear_cache[clear-nscd-caches]', :immediately
 end
 ```
 


### PR DESCRIPTION
The resource expects `:clear` instead of `:run`. Adjusting documentation accordingly.

Obvious fix.