### PR TITLE
Refer to "databases" as "new_resource.databases"

### DIFF
--- a/resources/clear_cache.rb
+++ b/resources/clear_cache.rb
@@ -20,7 +20,7 @@
 property :databases, Array, default: %w(passwd group hosts services netgroup)
 
 action :clear do
-  databases.each do |cmd|
+  new_resource.databases.each do |cmd|
     execute "nscd-clear-#{cmd}" do
       command "/usr/sbin/nscd -i #{cmd}"
       action :run


### PR DESCRIPTION
Chef 13.8 shows a deprecation warning:

   Deprecated features used!
   rename databases to new_resource.databases at 1 location:
     - /tmp/kitchen/cache/cookbooks/nscd/resources/clear_cache.rb:23:in `block in class_from_file'
    See https://docs.chef.io/deprecations_namespace_collisions.html for further details.

which results in an error in Chef 14:
```
 undefined local variable or method `databases' for #<#Class:0x0000000004593a18>:0x0000000004448fc8>
```

Signed-off-by: Sean Walberg <sean@ertw.com>

### Description

Fixes error in Chef 14.
### Issues Resolved

Not currently filed as an issue.
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
